### PR TITLE
Add option to include ADR status in TOC

### DIFF
--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -16,7 +16,7 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## Both INTRO and OUTRO must be in Markdown format.
 
-args=$(getopt i:o:p:s $*)
+args=$(getopt s:i:o:p $*)
 set -- $args
 
 link_prefix=

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -2,12 +2,13 @@
 set -e
 eval "$($(dirname $0)/adr-config)"
 
-## usage: adr generate toc [-i INTRO] [-o OUTRO] [-p LINK_PREFIX]
+## usage: adr generate toc [-s] [-i INTRO] [-o OUTRO] [-p LINK_PREFIX]
 ##
 ## Generates a table of contents in Markdown format to stdout.
 ##
 ## Options:
 ##
+## -s        include the state of each decision next to its link.
 ## -i INTRO  precede the table of contents with the given INTRO text.
 ## -o OUTRO  follow the table of contents with the given OUTRO text.
 ## -p LINK_PREFIX

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -16,7 +16,7 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## Both INTRO and OUTRO must be in Markdown format.
 
-args=$(getopt s:i:o:p $*)
+args=$(getopt si:o:p: $*)
 set -- $args
 
 link_prefix=
@@ -26,6 +26,10 @@ for arg
 do
     case "$arg"
     in
+        -s)
+            output_status=1
+            shift
+            ;;
         -i)
             intro="$2"
             shift 2
@@ -37,10 +41,6 @@ do
         -p)
             link_prefix="$2"
             shift 2
-            ;;
-        -s)
-            output_status=1
-            shift
             ;;
         --)
             shift

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -10,15 +10,16 @@ eval "$($(dirname $0)/adr-config)"
 ##
 ## -i INTRO  precede the table of contents with the given INTRO text.
 ## -o OUTRO  follow the table of contents with the given OUTRO text.
-## -p LINK_PREFIX   
+## -p LINK_PREFIX
 ##           prefix each decision file link with LINK_PREFIX.
 ##
 ## Both INTRO and OUTRO must be in Markdown format.
 
-args=$(getopt i:o:p: $*)
+args=$(getopt i:o:p:s $*)
 set -- $args
 
 link_prefix=
+output_status=
 
 for arg
 do
@@ -35,6 +36,10 @@ do
         -p)
             link_prefix="$2"
             shift 2
+            ;;
+        -s)
+            output_status=1
+            shift
             ;;
         --)
             shift
@@ -58,8 +63,9 @@ for f in $("$adr_bin_dir/adr-list")
 do
     title=$("$adr_bin_dir/_adr_title" $f)
     link=${link_prefix}$(basename $f)
+    status=${output_status:+": $("$adr_bin_dir/_adr_status" $f | tail -n 1)"}
 
-    echo "* [$title]($link)"
+    echo -e "* [$title]($link)$status"
 done
 
 if [ ! -z $outro ]

--- a/src/_adr_generate_toc
+++ b/src/_adr_generate_toc
@@ -63,7 +63,15 @@ for f in $("$adr_bin_dir/adr-list")
 do
     title=$("$adr_bin_dir/_adr_title" $f)
     link=${link_prefix}$(basename $f)
-    status=${output_status:+": $("$adr_bin_dir/_adr_status" $f | tail -n 1)"}
+    status=
+
+    if [[ "$output_status" == "1" ]]; then
+      # We're only interested in the first line of the status (e.g. Accepted).
+      # Second line, if any, will be a reference to another ADR that supercedes
+      # this record, that this record supercedes or that amends it.
+      # Additionally, prefix ADR links if prefix specified.
+      status=": $("$adr_bin_dir/_adr_status" $f | head -n 1 | sed -E -e "s/\((.+\.md)\)/(${link_prefix//\//\\/}\1)/")"
+    fi
 
     echo -e "* [$title]($link)$status"
 done

--- a/tests/generate-contents-with-status-and-prefix.expected
+++ b/tests/generate-contents-with-status-and-prefix.expected
@@ -1,0 +1,15 @@
+adr new First Decision
+doc/adr/0001-first-decision.md
+adr new Second Decision
+doc/adr/0002-second-decision.md
+adr new Third Decision
+doc/adr/0003-third-decision.md
+adr new -s 3 Fourth Decision
+doc/adr/0004-fourth-decision.md
+adr generate toc -p foo/doc/adr/ -s
+# Architecture Decision Records
+
+* [1. First Decision](foo/doc/adr/0001-first-decision.md): Accepted
+* [2. Second Decision](foo/doc/adr/0002-second-decision.md): Accepted
+* [3. Third Decision](foo/doc/adr/0003-third-decision.md): Superceded by [4. Fourth Decision](foo/doc/adr/0004-fourth-decision.md)
+* [4. Fourth Decision](foo/doc/adr/0004-fourth-decision.md): Accepted

--- a/tests/generate-contents-with-status-and-prefix.sh
+++ b/tests/generate-contents-with-status-and-prefix.sh
@@ -1,0 +1,5 @@
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr new -s 3 Fourth Decision
+adr generate toc -p foo/doc/adr/ -s

--- a/tests/generate-contents-with-status-header-and-footer.expected
+++ b/tests/generate-contents-with-status-header-and-footer.expected
@@ -1,0 +1,29 @@
+adr new First Decision
+doc/adr/0001-first-decision.md
+adr new Second Decision
+doc/adr/0002-second-decision.md
+adr new Third Decision
+doc/adr/0003-third-decision.md
+adr new -s 3 Fourth Decision
+doc/adr/0004-fourth-decision.md
+cat > intro.md <<EOF
+An intro.
+
+Multiple paragraphs.
+EOF
+cat > outro.md <<EOF
+An outro.
+EOF
+adr generate toc -i intro.md -o outro.md -s
+# Architecture Decision Records
+
+An intro.
+
+Multiple paragraphs.
+
+* [1. First Decision](0001-first-decision.md): Accepted
+* [2. Second Decision](0002-second-decision.md): Accepted
+* [3. Third Decision](0003-third-decision.md): Superceded by [4. Fourth Decision](0004-fourth-decision.md)
+* [4. Fourth Decision](0004-fourth-decision.md): Accepted
+
+An outro.

--- a/tests/generate-contents-with-status-header-and-footer.sh
+++ b/tests/generate-contents-with-status-header-and-footer.sh
@@ -1,0 +1,13 @@
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr new -s 3 Fourth Decision
+cat > intro.md <<EOF
+An intro.
+
+Multiple paragraphs.
+EOF
+cat > outro.md <<EOF
+An outro.
+EOF
+adr generate toc -i intro.md -o outro.md -s

--- a/tests/generate-contents-with-status.expected
+++ b/tests/generate-contents-with-status.expected
@@ -1,0 +1,15 @@
+adr new First Decision
+doc/adr/0001-first-decision.md
+adr new Second Decision
+doc/adr/0002-second-decision.md
+adr new Third Decision
+doc/adr/0003-third-decision.md
+adr new -s 3 Fourth Decision
+doc/adr/0004-fourth-decision.md
+adr generate toc -s
+# Architecture Decision Records
+
+* [1. First Decision](0001-first-decision.md): Accepted
+* [2. Second Decision](0002-second-decision.md): Accepted
+* [3. Third Decision](0003-third-decision.md): Superceded by [4. Fourth Decision](0004-fourth-decision.md)
+* [4. Fourth Decision](0004-fourth-decision.md): Accepted

--- a/tests/generate-contents-with-status.sh
+++ b/tests/generate-contents-with-status.sh
@@ -1,0 +1,5 @@
+adr new First Decision
+adr new Second Decision
+adr new Third Decision
+adr new -s 3 Fourth Decision
+adr generate toc -s


### PR DESCRIPTION
It would be ideal if we could include the status of each ADR in the table of contents.

The intended use is:

```
$ adr generate toc -s
# Architecture Decision Records

* [1. Record architecture decisions](0001-record-architecture-decisions.md): Accepted
* [2. Implement as shell scripts](0002-implement-as-shell-scripts.md): Accepted
* [3. Single command with subcommands](0003-single-command-with-subcommands.md): Accepted
* [4. Markdown format](0004-markdown-format.md): Accepted
* [5. Help comments](0005-help-comments.md): Amended by [9. Help scripts](0009-help-scripts.md)
* [6. Packaging and distribution in other version control repositories](0006-packaging-and-distribution-in-other-version-control-repositories.md): Accepted
* [7. Invoke adr-config executable to get configuration](0007-invoke-adr-config-executable-to-get-configuration.md): Accepted
* [8. Use ISO 8601 Format for Dates](0008-use-iso-8601-format-for-dates.md): Accepted
* [9. Help scripts](0009-help-scripts.md): Amends [5. Help comments](0005-help-comments.md)
```

I made the decision to only keep the last line under the _Status_ section so that amendments are properly printed with their links.